### PR TITLE
Fix problem with display of headings in some situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [1.0.2] - 2015-12-12
+
+### Changed
+- Amended the headers that are output in the report as they would not display properly in some Markdown environments, e.g. in the Atom editor 'Markdown Preview' window '##Linting' would display as exactly that, not be expanded to an 'H2'-style header.
+Adding a space after the '#' - '## Linting' - ensures that the headings should always display properly.
+
+
 ## [1.0.1] - 2015-12-07
 
 ### Changed

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -14,11 +14,11 @@ exports = module.exports = internals.Reporter = function (options) {
 
 internals.Reporter.prototype.start = function (notebook) {
 
-    this.report('#Code Quality Report  \n');
+    this.report('# Code Quality Report  \n');
 
     const d = new Date();
     this.report(d.toDateString() + ' ' + d.toTimeString()) + '  \n';
-    this.report('  \n  \n##Tests\n  ');
+    this.report('  \n  \n## Tests\n  ');
 };
 
 
@@ -87,12 +87,12 @@ internals.filterNodeModules = function (line) {
 internals.filterSkipped = function (test) {
 
     return test.skipped;
-};
+}; 
 
 
 internals.linting = function (lint, settings) {
 
-    let output = '  \n  \n##Linting  \n';
+    let output = '  \n  \n## Linting  \n';
 
     output += 'Warnings threshold: ' + settings['lint-warnings-threshold'] + '  \n';
     output += 'Errors threshold: ' + settings['lint-errors-threshold'] + '  \n';
@@ -123,7 +123,7 @@ internals.linting = function (lint, settings) {
 
 internals.coverage = function (coverage, settings) {
 
-    let output = '  \n  \n##Coverage  \n';
+    let output = '  \n  \n## Coverage  \n';
 
     output += 'Threshold: ' + settings.threshold + '%  \n';
 
@@ -185,7 +185,7 @@ internals.coverage = function (coverage, settings) {
 
 internals.leaks = function (leaks) {
 
-    let output = '  \n  \n##Leaks  \n';
+    let output = '  \n  \n## Leaks  \n';
 
     if (leaks.length) {
         output += 'The following global variable leaks were detected:' + leaks.join(', ') + '  \n';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lab-markdown-reporter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Markdown reporter for Hapi's Lab test runner",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
Amend the headers that are output in the report as they would not display properly in some Markdown environments, e.g. in the Atom editor 'Markdown Preview' window '##Linting' would display as exactly that, not be expanded to an 'H2'-style header.

Fixes #1
